### PR TITLE
Admin/experiments/pre commit branch name

### DIFF
--- a/admin/hooks/pre-commit
+++ b/admin/hooks/pre-commit
@@ -2,7 +2,7 @@
 LC_ALL=C
 local_branch="$(git rev-parse --abbrev-ref HEAD)"
 echo "Verifying branch $local_branch".
-valid_branch_regex="^(feature|bugfix|improvement|library|prerelease|release|hotfix|admin)(\/(experiments))?(\/[a-z0-9._-]+)+$"
+valid_branch_regex="^(feature|bugfix|improvement|library|prerelease|release|hotfix|admin)(\/experiments)?(\/[a-z0-9._-]+)+$"
 message= "Invalid branch name. Branch names in this project must be of the form  $valid_branch_regex."
 if [[ ! $local_branch =~ $valid_branch_regex ]]
 then

--- a/admin/hooks/pre-commit
+++ b/admin/hooks/pre-commit
@@ -2,7 +2,7 @@
 LC_ALL=C
 local_branch="$(git rev-parse --abbrev-ref HEAD)"
 echo "Verifying branch $local_branch".
-valid_branch_regex="^(feature|bugfix|improvement|library|prerelease|release|hotfix|admin)(\/(experiments))?\/[a-z0-9._-]+$"
+valid_branch_regex="^(feature|bugfix|improvement|library|prerelease|release|hotfix|admin)(\/(experiments))?(\/[a-z0-9._-]+)+$"
 message= "Invalid branch name. Branch names in this project must be of the form  $valid_branch_regex."
 if [[ ! $local_branch =~ $valid_branch_regex ]]
 then

--- a/admin/hooks/pre-commit
+++ b/admin/hooks/pre-commit
@@ -10,3 +10,4 @@ then
     exit 1
 fi
 exit 0
+# a hardcore python option: https://stackoverflow.com/questions/12093748/how-do-i-check-for-valid-git-branch-names

--- a/admin/hooks/pre-commit
+++ b/admin/hooks/pre-commit
@@ -2,8 +2,8 @@
 LC_ALL=C
 local_branch="$(git rev-parse --abbrev-ref HEAD)"
 echo "Verifying branch $local_branch".
-valid_branch_regex="(feature|bugfix|improvement|library|prerelease|release|hotfix|admin)(\/experiments)?(\/[a-z0-9._-]+)+"
-message= "Invalid branch name. Branch names in this project must be of the form  $valid_branch_regex."
+valid_branch_regex="^(feature|bugfix|improvement|library|prerelease|release|hotfix|admin)(\/experiments)?(\/[a-z0-9._-]+)+$"
+message="Invalid branch name. Branch names in this project must be of the form  $valid_branch_regex."
 if [[ ! $local_branch =~ $valid_branch_regex ]]
 then
     echo "$message"

--- a/admin/hooks/pre-commit
+++ b/admin/hooks/pre-commit
@@ -2,7 +2,7 @@
 LC_ALL=C
 local_branch="$(git rev-parse --abbrev-ref HEAD)"
 echo "Verifying branch $local_branch".
-valid_branch_regex="^(feature|bugfix|improvement|library|prerelease|release|hotfix|admin)(\/experiments)?(\/[a-z0-9._-]+)+$"
+valid_branch_regex="(feature|bugfix|improvement|library|prerelease|release|hotfix|admin)(\/experiments)?(\/[a-z0-9._-]+)+"
 message= "Invalid branch name. Branch names in this project must be of the form  $valid_branch_regex."
 if [[ ! $local_branch =~ $valid_branch_regex ]]
 then

--- a/admin/hooks/pre-commit
+++ b/admin/hooks/pre-commit
@@ -2,7 +2,7 @@
 LC_ALL=C
 local_branch="$(git rev-parse --abbrev-ref HEAD)"
 echo "Verifying branch $local_branch".
-valid_branch_regex="^(feature|bugfix|improvement|library|prerelease|release|hotfix|admin)(\/experiments)*\/[a-z0-9._-]+$"
+valid_branch_regex="^(feature|bugfix|improvement|library|prerelease|release|hotfix|admin)(\/(experiments))?\/[a-z0-9._-]+$"
 message= "Invalid branch name. Branch names in this project must be of the form  $valid_branch_regex."
 if [[ ! $local_branch =~ $valid_branch_regex ]]
 then

--- a/admin/hooks/pre-commit
+++ b/admin/hooks/pre-commit
@@ -2,8 +2,8 @@
 LC_ALL=C
 local_branch="$(git rev-parse --abbrev-ref HEAD)"
 echo "Verifying branch $local_branch".
-valid_branch_regex="^(feature|bugfix|improvement|library|prerelease|release|hotfix|admin)\/(experiments)+\/[a-z0-9._-]+$"
-message="Invalid branch name. Branch names in this project must be of the form $valid_branch_regex."
+valid_branch_regex="^(feature|bugfix|improvement|library|prerelease|release|hotfix|admin)(\/experiments)*\/[a-z0-9._-]+$"
+message= "Invalid branch name. Branch names in this project must be of the form  $valid_branch_regex."
 if [[ ! $local_branch =~ $valid_branch_regex ]]
 then
     echo "$message"


### PR DESCRIPTION
Imrpoved my experiments for a very basic hook protection that allows various sub-branch naming options, as well as experiment sub-branches, while permitting the scheme I want, though it doesn't enforce naming as well as the URL pasted at the end of the hook file.